### PR TITLE
Fix ToSql Formating Order

### DIFF
--- a/WDBXEditor/Common/Extensions.cs
+++ b/WDBXEditor/Common/Extensions.cs
@@ -134,7 +134,7 @@ namespace WDBXEditor.Common
             {
                 if (cols[i].DataType == typeof(string)) //Escape formatting
                 {
-                    string val = row[i].ToString().Replace(@"'", @"\'").Replace(@"""", @"\""").Replace(@"\", @"\\");
+                    string val = row[i].ToString().Replace(@"\", @"\\").Replace(@"'", @"\'").Replace(@"""", @"\""");
                     sb.Append("\"" + val + "\",");
                 }
                 else if (cols[i].DataType == typeof(float))


### PR DESCRIPTION
The current order of the ToSql produces an error because it escapes "\\" from the other escaped chracters like '"".
Example:
`INSERT INTO db_Spell_12340 VALUES (9192,0,0,0,327680,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,1024,0,0,101,0,0,1,1,4,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,-1,0,0,6,0,0,1,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,56,0,0,0,0,0,0,0,0,0,0,0,0,0,0,6666,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1464,0,107,131,0,"\\"Plucky\\" Resumes Human Form","","","","","","","","","","","","","","","",16712190,"Shapeshift","","","","","","","","","","","","","","","",16712190,"","","","","","","","","","","","","","","","",16712188,"","","","","","","","","","","","","","","","",16712188,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,0,0,0,0,0,0,8,0,0,0,0,0,0,0,0);
`
Corrected with the order fix:
`INSERT INTO db_Spell_12340 VALUES (9192,0,0,0,327680,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,1024,0,0,101,0,0,1,1,4,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,-1,0,0,6,0,0,1,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,56,0,0,0,0,0,0,0,0,0,0,0,0,0,0,6666,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1464,0,107,131,0,"\"Plucky\" Resumes Human Form","","","","","","","","","","","","","","","",16712190,"Shapeshift","","","","","","","","","","","","","","","",16712190,"","","","","","","","","","","","","","","","",16712188,"","","","","","","","","","","","","","","","",16712188,0,0,0,0,0,0,0,0,0,0,0,0,1,1,1,0,0,0,0,0,0,8,0,0,0,0,0,0,0,0);
`