### PR TITLE
remove duplicate id field in wotlks Cfg_Configs def

### DIFF
--- a/WDBXEditor/Definitions/WotLK 3.3.5 (12340).xml
+++ b/WDBXEditor/Definitions/WotLK 3.3.5 (12340).xml
@@ -245,7 +245,6 @@
   </Table>
   <Table Name="Cfg_Configs" Build="12340">
     <Field Name="ID" Type="int" IsIndex="true" AutoGenerate="true" />
-    <Field Name="ID" Type="int" />
     <Field Name="RealmType" Type="int" />
     <Field Name="PlayerKillingAllowed" Type="int" />
     <Field Name="Roleplaying" Type="int" />


### PR DESCRIPTION
Fix duplicate column error when opening Cfg_Configs.dbc with wotlk settings. There is no secondary id column in Cfg_Configs.dbc for 12340.