### PR TITLE
Fix CSV import failing when '\n' or '\r' is present in a string

### DIFF
--- a/WDBXEditor/Storage/DBEntry.cs
+++ b/WDBXEditor/Storage/DBEntry.cs
@@ -670,7 +670,30 @@ namespace WDBXEditor.Storage
 
 					while (!sr.EndOfStream)
 					{
-						string line = sr.ReadLine();
+						string line = "";
+
+						// if it's not the end of the file, read the 2 first char
+						if (sr.EndOfStream)
+						{
+							break;
+						}
+						line += (char)sr.Read();
+
+						if (sr.EndOfStream)
+						{
+							break;
+						}
+						line += (char)sr.Read();
+						
+						// while it's not the end of a row (marked by \r\n), neither the end of the file, append the chars to the line
+						while (line.Substring(line.Length-2) != "\r\n" && !sr.EndOfStream)
+						{
+							line += (char)sr.Read(); ;
+						}
+
+						// remove the \r\n last chars as the old code don't expect them
+						line = line.Remove(line.Length - 2);
+
 						string[] rows = Regex.Split(line, ",(?=(?:[^\"]*\"[^\"]*\")*(?![^\"]*\"))", RegexOptions.Compiled);
 						DataRow dr = importTable.NewRow();
 


### PR DESCRIPTION
fix #115