### PR TITLE
fix: wotlk 3.3.5a (12340) Spell.dbc definition

### DIFF
--- a/WDBXEditor/Definitions/WotLK 3.3.5 (12340).xml
+++ b/WDBXEditor/Definitions/WotLK 3.3.5 (12340).xml
@@ -1573,7 +1573,7 @@
     <Field Name="AttributesExF" Type="uint" />
     <Field Name="AttributesExG" Type="uint" />
     <Field Name="ShapeshiftMask" Type="uint" />
-    <Field Name="unk_320_2" Type="ulong" />
+    <Field Name="unk_320_2" Type="uint" />
     <Field Name="ShapeshiftExclude" Type="uint" />
     <Field Name="unk_320_3" Type="uint" />
     <Field Name="Targets" Type="uint" />

--- a/WDBXEditor/Definitions/WotLK 3.3.5 (12340).xml
+++ b/WDBXEditor/Definitions/WotLK 3.3.5 (12340).xml
@@ -1572,8 +1572,10 @@
     <Field Name="AttributesExE" Type="uint" />
     <Field Name="AttributesExF" Type="uint" />
     <Field Name="AttributesExG" Type="uint" />
-    <Field Name="ShapeshiftMask" Type="ulong" />
-    <Field Name="ShapeshiftExclude" Type="ulong" />
+    <Field Name="ShapeshiftMask" Type="uint" />
+    <Field Name="unk_320_2" Type="ulong" />
+    <Field Name="ShapeshiftExclude" Type="uint" />
+    <Field Name="unk_320_3" Type="uint" />
     <Field Name="Targets" Type="uint" />
     <Field Name="TargetCreatureType" Type="uint" />
     <Field Name="RequiresSpellFocus" Type="uint" />

--- a/WDBXEditor/Definitions/WotLK 3.3.5 (12340).xml
+++ b/WDBXEditor/Definitions/WotLK 3.3.5 (12340).xml
@@ -1572,9 +1572,9 @@
     <Field Name="AttributesExE" Type="uint" />
     <Field Name="AttributesExF" Type="uint" />
     <Field Name="AttributesExG" Type="uint" />
-    <Field Name="ShapeshiftMask" Type="uint" />
+    <Field Name="Stances" Type="uint" />
     <Field Name="unk_320_2" Type="uint" />
-    <Field Name="ShapeshiftExclude" Type="uint" />
+    <Field Name="StancesNot" Type="uint" />
     <Field Name="unk_320_3" Type="uint" />
     <Field Name="Targets" Type="uint" />
     <Field Name="TargetCreatureType" Type="uint" />


### PR DESCRIPTION
You are considering `ShapeshiftMask` and `ShapeshiftExclude` as `ulong`, considering 2 fields instead of 4.

Several sources are considering 4 fields instead of two, I will list them:
[wowdev wiki](https://wowdev.wiki/DB/Spell) 
[WoW-Spell-Editor](https://github.com/stoneharry/WoW-Spell-Editor/blob/master/Documentation/Bindings_335_wotlk/Spell.txt)
[wowgaming node-dbc-reader](https://github.com/wowgaming/node-dbc-reader/blob/master/src/schemas/azerothcore/spell.json)
[AzerothCore DBCStructure.h](https://github.com/azerothcore/azerothcore-wotlk/blob/master/src/server/shared/DataStores/DBCStructure.h#L1653)

They are also calling these fields `Stances` and `StancesNot`.

Only TrinityCore seems to `pair` the 4 fields into 2, but still using couple of uint32 ([source](https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/shared/DataStores/DBCStructure.h#L1411C27-L1411C41)).
